### PR TITLE
removed: redundant logo class

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </head>
     <body>
         <div class="header">
-            <a class="logo">Peter Liu's Portfolio</a>
+            <a>Peter Liu's Portfolio</a>
             <div class="header-links">
                 <a href="index.html">Home</a>
                 <a href="about.html">About</a>


### PR DESCRIPTION
Logo class for top left "portfolio" text was removed for redundancy, as it is already handled by the header class.